### PR TITLE
URL Cleanup

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -5,7 +5,7 @@ if [ ! -d "$ANDROID_HOME" ]; then
     if [[ "$OSTYPE" == "linux-gnu" ]]; then
         export ANDROID_HOME=${WORKSPACE}/android-sdk-linux 
         export PATH=${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${PATH}
-        wget http://dl.google.com/android/android-sdk_r22.6.2-linux.tgz -nv
+        wget https://dl.google.com/android/android-sdk_r22.6.2-linux.tgz -nv
         tar xzf android-sdk_r22.6.2-linux.tgz
         echo "y" | android update sdk -f -u -a -t tools,platform-tools,build-tools-19.0.3,build-tools-19.0.0,build-tools-18.1.1,build-tools-18.1.0,build-tools-18.0.1,build-tools-17.0.0,android-19,extra-android-m2repository,extra-android-support
     #elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/spring-android-basic-auth/client/build.gradle
+++ b/spring-android-basic-auth/client/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'android'
 
 repositories {
     mavenCentral()
-    maven { url 'http://repo.spring.io/libs-release' }
+    maven { url 'https://repo.spring.io/libs-release' }
 }
 
 dependencies {

--- a/spring-android-basic-auth/client/pom.xml
+++ b/spring-android-basic-auth/client/pom.xml
@@ -7,11 +7,11 @@
 	<version>0.1.0</version>
 	<packaging>apk</packaging>
 	<name>spring-android-basic-auth-client</name>
-	<url>http://spring.io/projects/spring-android</url>
+	<url>https://spring.io/projects/spring-android</url>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 
 	<properties>
@@ -51,7 +51,7 @@
 		<repository>
 			<id>spring-repo</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/spring-android-basic-auth/server/build.gradle
+++ b/spring-android-basic-auth/server/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
 		mavenCentral()
-		maven { url "http://repo.spring.io/libs-release" }
+		maven { url "https://repo.spring.io/libs-release" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.0.2.RELEASE")
@@ -20,7 +20,7 @@ jar {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 dependencies {

--- a/spring-android-basic-auth/server/pom.xml
+++ b/spring-android-basic-auth/server/pom.xml
@@ -49,14 +49,14 @@
 	<repositories>
 		<repository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/spring-android-facebook-client/build.gradle
+++ b/spring-android-facebook-client/build.gradle
@@ -18,7 +18,7 @@ configurations.compile {
 
 repositories {
     mavenCentral()
-    maven { url 'http://repo.spring.io/libs-release' }
+    maven { url 'https://repo.spring.io/libs-release' }
 }
 
 dependencies {

--- a/spring-android-facebook-client/pom.xml
+++ b/spring-android-facebook-client/pom.xml
@@ -7,11 +7,11 @@
 	<version>0.1.0</version>
 	<packaging>apk</packaging>
 	<name>spring-android-facebook-client</name>
-	<url>http://spring.io/projects/spring-android</url>
+	<url>https://spring.io/projects/spring-android</url>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 
 	<properties>
@@ -100,7 +100,7 @@
 		<repository>
 			<id>spring-repo</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/spring-android-news-reader/build.gradle
+++ b/spring-android-news-reader/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'android'
 
 repositories {
     mavenCentral()
-    maven { url 'http://repo.spring.io/libs-release' }
+    maven { url 'https://repo.spring.io/libs-release' }
     maven { url 'https://android-rome-feed-reader.googlecode.com/svn/maven2/releases' }
 }
 

--- a/spring-android-news-reader/pom.xml
+++ b/spring-android-news-reader/pom.xml
@@ -7,11 +7,11 @@
 	<version>0.1.0</version>
 	<packaging>apk</packaging>
 	<name>spring-android-news-reader</name>
-	<url>http://spring.io/projects/spring-android</url>
+	<url>https://spring.io/projects/spring-android</url>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 
 	<properties>
@@ -56,7 +56,7 @@
 		<repository>
 			<id>spring-repo</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/spring-android-showcase/client/build.gradle
+++ b/spring-android-showcase/client/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'android'
 
 repositories {
     mavenCentral()
-    maven { url 'http://repo.spring.io/libs-release' }
+    maven { url 'https://repo.spring.io/libs-release' }
 }
 
 dependencies {

--- a/spring-android-showcase/client/pom.xml
+++ b/spring-android-showcase/client/pom.xml
@@ -7,11 +7,11 @@
 	<version>0.1.0</version>
 	<packaging>apk</packaging>
 	<name>spring-android-showcase-client</name>
-	<url>http://spring.io/projects/spring-android</url>
+	<url>https://spring.io/projects/spring-android</url>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 
 	<properties>
@@ -79,7 +79,7 @@
 		<repository>
 			<id>spring-repo</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/spring-android-showcase/server/build.gradle
+++ b/spring-android-showcase/server/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
 		mavenCentral()
-		maven { url "http://repo.spring.io/libs-release" }
+		maven { url "https://repo.spring.io/libs-release" }
 	}
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.0.2.RELEASE")
@@ -20,7 +20,7 @@ jar {
 
 repositories {
 	mavenCentral()
-	maven { url "http://repo.spring.io/libs-release" }
+	maven { url "https://repo.spring.io/libs-release" }
 }
 
 dependencies {

--- a/spring-android-showcase/server/pom.xml
+++ b/spring-android-showcase/server/pom.xml
@@ -45,14 +45,14 @@
 	<repositories>
 		<repository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 
 	<pluginRepositories>
 		<pluginRepository>
 			<id>spring-releases</id>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/spring-android-twitter-client/build.gradle
+++ b/spring-android-twitter-client/build.gradle
@@ -18,7 +18,7 @@ configurations.compile {
 
 repositories {
     mavenCentral()
-    maven { url 'http://repo.spring.io/libs-release' }
+    maven { url 'https://repo.spring.io/libs-release' }
 }
 
 dependencies {

--- a/spring-android-twitter-client/pom.xml
+++ b/spring-android-twitter-client/pom.xml
@@ -7,11 +7,11 @@
 	<version>0.1.0</version>
 	<packaging>apk</packaging>
 	<name>spring-android-twitter-client</name>
-	<url>http://spring.io/projects/spring-android</url>
+	<url>https://spring.io/projects/spring-android</url>
 	<inceptionYear>2010</inceptionYear>
 	<organization>
 		<name>Spring</name>
-		<url>http://spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 
 	<properties>
@@ -100,7 +100,7 @@
 		<repository>
 			<id>spring-repo</id>
 			<name>Spring Repository</name>
-			<url>http://repo.spring.io/libs-release</url>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://dl.google.com/android/android-sdk_r22.6.2-linux.tgz migrated to:  
  https://dl.google.com/android/android-sdk_r22.6.2-linux.tgz ([https](https://dl.google.com/android/android-sdk_r22.6.2-linux.tgz) result 200).
* http://spring.io migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://spring.io/projects/spring-android migrated to:  
  https://spring.io/projects/spring-android ([https](https://spring.io/projects/spring-android) result 200).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance