### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ $ adb devices
 [Spring for Android][spring-android] is released under version 2.0 of the [Apache License].
 
 
-[spring-android]: http://spring.io/projects/spring-android
-[Android SDK]: http://developer.android.com/sdk/index.html
-[Maven]: http://maven.apache.org
-[Android Maven Plugin]: http://code.google.com/p/maven-android-plugin
+[spring-android]: https://spring.io/projects/spring-android
+[Android SDK]: https://developer.android.com/sdk/index.html
+[Maven]: https://maven.apache.org
+[Android Maven Plugin]: https://code.google.com/p/maven-android-plugin
 [Spring for Android on GitHub]: https://github.com/spring-projects/spring-android
 [spring-android-showcase]: https://github.com/spring-projects/spring-android-samples/tree/master/spring-android-showcase
 [spring-android-news-reader]: https://github.com/spring-projects/spring-android-samples/tree/master/spring-android-news-reader
@@ -174,13 +174,13 @@ $ adb devices
 [spring-android-twitter-client]: https://github.com/spring-projects/spring-android-samples/tree/master/spring-android-twitter-client
 [spring-android-facebook-client]: https://github.com/spring-projects/spring-android-samples/tree/master/spring-android-facebook-client
 [spring-android-basic-auth]: https://github.com/spring-projects/spring-android-samples/tree/master/spring-android-basic-auth
-[Eclipse Plugin]: http://developer.android.com/sdk/eclipse-adt.html
-[installation details]: http://developer.android.com/sdk/installing.html
-[Android 2.1 SDK Platform]: http://developer.android.com/sdk/android-2.1.html
-[Managing Virtual Devices]: http://developer.android.com/tools/devices/index.html
-[Pull requests]: http://help.github.com/send-pull-requests
+[Eclipse Plugin]: https://developer.android.com/sdk/eclipse-adt.html
+[installation details]: https://developer.android.com/sdk/installing.html
+[Android 2.1 SDK Platform]: https://developer.android.com/sdk/android-2.1.html
+[Managing Virtual Devices]: https://developer.android.com/tools/devices/index.html
+[Pull requests]: https://help.github.com/send-pull-requests
 [contributor guidelines]: https://github.com/spring-projects/spring-android/wiki/Contributor-Guidelines
 [Gradle Plugin User Guide]: http://tools.android.com/tech-docs/new-build-system/user-guide
-[Android Maven Plugin Documentation]: http://maven-android-plugin-m2site.googlecode.com/svn/plugin-info.html
-[Android Developers web site]: http://developer.android.com/index.html
+[Android Maven Plugin Documentation]: https://maven-android-plugin-m2site.googlecode.com/svn/plugin-info.html
+[Android Developers web site]: https://developer.android.com/index.html
 [Apache license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/spring-android-basic-auth/README.md
+++ b/spring-android-basic-auth/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This sample includes an Android client and a Spring MVC server. Together these illustrate the interaction of the client and server when using [Spring for Android](http://projects.spring.io/spring-android/) to make Basic Auth requests. This Android project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
+This sample includes an Android client and a Spring MVC server. Together these illustrate the interaction of the client and server when using [Spring for Android](https://projects.spring.io/spring-android/) to make Basic Auth requests. This Android project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
 
 
 ## Build and Run the Server

--- a/spring-android-basic-auth/server/src/main/resources/templates/home.html
+++ b/spring-android-basic-auth/server/src/main/resources/templates/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head> 
     <title>Spring for Android Showcase</title> 
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/spring-android-facebook-client/README.md
+++ b/spring-android-facebook-client/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This sample app includes an Android client which connects to Facebook. This illustrate the integration of [Spring Social](http://projects.spring.io/spring-social/) with [Spring for Android](http://projects.spring.io/spring-android/). The Android project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
+This sample app includes an Android client which connects to Facebook. This illustrate the integration of [Spring Social](https://projects.spring.io/spring-social/) with [Spring for Android](https://projects.spring.io/spring-android/). The Android project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
 
 ## Build and run the Android App
 

--- a/spring-android-facebook-client/src/org/springframework/android/facebookclient/FacebookWebOAuthActivity.java
+++ b/spring-android-facebook-client/src/org/springframework/android/facebookclient/FacebookWebOAuthActivity.java
@@ -126,7 +126,7 @@ public class FacebookWebOAuthActivity extends AbstractWebViewActivity {
 			 * The access token is returned in the URI fragment of the URL. See the Desktop Apps section all the way 
 			 * at the bottom of this link:
 			 * 
-			 * http://developers.facebook.com/docs/authentication/
+			 * https://developers.facebook.com/docs/authentication/
 			 * 
 			 * The fragment will be formatted like this:
 			 * 

--- a/spring-android-news-reader/README.md
+++ b/spring-android-news-reader/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Spring for Android News Reader sample app illustrates the use of [Spring for Android](http://projects.spring.io/spring-android/) and the [Android ROME Feed Reader](http://code.google.com/p/android-rome-feed-reader/) to retrieve RSS and Atom news feeds. This project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
+The Spring for Android News Reader sample app illustrates the use of [Spring for Android](https://projects.spring.io/spring-android/) and the [Android ROME Feed Reader](https://code.google.com/p/android-rome-feed-reader/) to retrieve RSS and Atom news feeds. This project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
 
 ## Build and Run the Android App
 

--- a/spring-android-showcase/README.md
+++ b/spring-android-showcase/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This showcase includes an Android client and a Spring MVC server. Together these illustrate the interaction of the client and server when using [Spring for Android](http://projects.spring.io/spring-android/).  This Android project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
+This showcase includes an Android client and a Spring MVC server. Together these illustrate the interaction of the client and server when using [Spring for Android](https://projects.spring.io/spring-android/).  This Android project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
 
 
 ## Build and Run the Server

--- a/spring-android-showcase/client/src/org/springframework/android/showcase/rest/HttpGetGzipCompressedActivity.java
+++ b/spring-android-showcase/client/src/org/springframework/android/showcase/rest/HttpGetGzipCompressedActivity.java
@@ -90,7 +90,7 @@ public class HttpGetGzipCompressedActivity extends AbstractAsyncActivity {
 		protected ResponseEntity<String> doInBackground(Void... params) {
 			try {
 				// The URL for making the GET request
-				final String url = "http://search.twitter.com/search.json?q={query}&rpp=100";
+				final String url = "https://search.twitter.com/search.json?q={query}&rpp=100";
 
 				// Add the gzip Accept-Encoding header to the request
 				HttpHeaders requestHeaders = new HttpHeaders();

--- a/spring-android-showcase/client/src/org/springframework/android/showcase/rest/HttpGetGzipCompressedJsonActivity.java
+++ b/spring-android-showcase/client/src/org/springframework/android/showcase/rest/HttpGetGzipCompressedJsonActivity.java
@@ -91,7 +91,7 @@ public class HttpGetGzipCompressedJsonActivity extends AbstractAsyncActivity {
 		protected ResponseEntity<TwitterSearchResults> doInBackground(Void... params) {
 			try {
 				// The URL for making the GET request
-				final String url = "http://search.twitter.com/search.json?q={query}&rpp=100";
+				final String url = "https://search.twitter.com/search.json?q={query}&rpp=100";
 
 				// Add the gzip Accept-Encoding header to the request
 				HttpHeaders requestHeaders = new HttpHeaders();

--- a/spring-android-showcase/client/src/org/springframework/android/showcase/rest/HttpGetGzipUncompressedActivity.java
+++ b/spring-android-showcase/client/src/org/springframework/android/showcase/rest/HttpGetGzipUncompressedActivity.java
@@ -92,7 +92,7 @@ public class HttpGetGzipUncompressedActivity extends AbstractAsyncActivity {
 		protected ResponseEntity<String> doInBackground(Void... params) {
 			try {
 				// The URL for making the GET request
-				final String url = "http://search.twitter.com/search.json?q={query}&rpp=100";
+				final String url = "https://search.twitter.com/search.json?q={query}&rpp=100";
 
 				// Add the Identity Accept-Encoding header to the request
 				// This disables gzip compression in Gingerbread (2.3) and newer

--- a/spring-android-showcase/server/src/main/resources/templates/fileupload.html
+++ b/spring-android-showcase/server/src/main/resources/templates/fileupload.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head> 
     <title>Spring for Android Showcase</title> 
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/spring-android-showcase/server/src/main/resources/templates/home.html
+++ b/spring-android-showcase/server/src/main/resources/templates/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="https://www.thymeleaf.org">
 <head> 
     <title>Spring for Android Showcase</title> 
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/spring-android-twitter-client/README.md
+++ b/spring-android-twitter-client/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This sample app includes an Android client which connects to Twitter. This illustrate the integration of [Spring Social](http://projects.spring.io/spring-social/) with [Spring for Android](http://projects.spring.io/spring-android/). The Android project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
+This sample app includes an Android client which connects to Twitter. This illustrate the integration of [Spring Social](https://projects.spring.io/spring-social/) with [Spring for Android](https://projects.spring.io/spring-android/). The Android project requires set up of the Android SDK. See the main [README](../README.md) at the root of this repository for more information about configuring your environment.
 
 
 ## Build and Run the Android App

--- a/spring-android-twitter-search/README.md
+++ b/spring-android-twitter-search/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Spring for Android Twitter Search sample app demonstrates the use of [Spring for Android](http://projects.spring.io/spring-android/) to make a RESTful request to the Twitter search API, without the use of Maven dependency management. This project requires set up of the Android SDK, and uses Ant to build and deploy the app to the emulator. See the main README at the root of this repository for more information about configuring your environment.
+The Spring for Android Twitter Search sample app demonstrates the use of [Spring for Android](https://projects.spring.io/spring-android/) to make a RESTful request to the Twitter search API, without the use of Maven dependency management. This project requires set up of the Android SDK, and uses Ant to build and deploy the app to the emulator. See the main README at the root of this repository for more information about configuring your environment.
 
 ## Build and Run the Android App
 

--- a/spring-android-twitter-search/proguard-project.txt
+++ b/spring-android-twitter-search/proguard-project.txt
@@ -8,7 +8,7 @@
 # include property in project.properties.
 #
 # For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+#   https://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
 

--- a/spring-android-twitter-search/src/org/springframework/android/twittersearch/TwitterSearchResultsActivity.java
+++ b/spring-android-twitter-search/src/org/springframework/android/twittersearch/TwitterSearchResultsActivity.java
@@ -129,7 +129,7 @@ public class TwitterSearchResultsActivity extends ListActivity {
 		protected ResponseEntity<TwitterSearchResults> doInBackground(String... params) {
 			try {
 				// The URL for making the GET request
-				final String url = "http://search.twitter.com/search.json?q={query}&rpp=20";
+				final String url = "https://search.twitter.com/search.json?q={query}&rpp=20";
 
 				// Add the gzip Accept-Encoding header to the request. This is not needed for Gingerbread and newer versions of Android
 				HttpHeaders requestHeaders = new HttpHeaders();


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://tools.android.com/tech-docs/new-build-system/user-guide (200) with 1 occurrences could not be migrated:  
   ([https](https://tools.android.com/tech-docs/new-build-system/user-guide) result ClosedChannelException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://help.github.com/send-pull-requests (404) with 1 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).
* [ ] http://maven-android-plugin-m2site.googlecode.com/svn/plugin-info.html (404) with 1 occurrences migrated to:  
  https://maven-android-plugin-m2site.googlecode.com/svn/plugin-info.html ([https](https://maven-android-plugin-m2site.googlecode.com/svn/plugin-info.html) result 404).
* [ ] http://search.twitter.com/search.json?q= (410) with 4 occurrences migrated to:  
  https://search.twitter.com/search.json?q= ([https](https://search.twitter.com/search.json?q=) result 410).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://developer.android.com/guide/developing/tools/proguard.html with 1 occurrences migrated to:  
  https://developer.android.com/guide/developing/tools/proguard.html ([https](https://developer.android.com/guide/developing/tools/proguard.html) result 200).
* [ ] http://developer.android.com/index.html with 1 occurrences migrated to:  
  https://developer.android.com/index.html ([https](https://developer.android.com/index.html) result 200).
* [ ] http://developer.android.com/sdk/android-2.1.html with 1 occurrences migrated to:  
  https://developer.android.com/sdk/android-2.1.html ([https](https://developer.android.com/sdk/android-2.1.html) result 200).
* [ ] http://developer.android.com/sdk/installing.html with 1 occurrences migrated to:  
  https://developer.android.com/sdk/installing.html ([https](https://developer.android.com/sdk/installing.html) result 200).
* [ ] http://developer.android.com/tools/devices/index.html with 1 occurrences migrated to:  
  https://developer.android.com/tools/devices/index.html ([https](https://developer.android.com/tools/devices/index.html) result 200).
* [ ] http://maven.apache.org with 1 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* [ ] http://projects.spring.io/spring-android/ with 6 occurrences migrated to:  
  https://projects.spring.io/spring-android/ ([https](https://projects.spring.io/spring-android/) result 200).
* [ ] http://projects.spring.io/spring-social/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-social/ ([https](https://projects.spring.io/spring-social/) result 200).
* [ ] http://spring.io/projects/spring-android with 1 occurrences migrated to:  
  https://spring.io/projects/spring-android ([https](https://spring.io/projects/spring-android) result 200).
* [ ] http://www.thymeleaf.org with 3 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://code.google.com/p/android-rome-feed-reader/ with 1 occurrences migrated to:  
  https://code.google.com/p/android-rome-feed-reader/ ([https](https://code.google.com/p/android-rome-feed-reader/) result 301).
* [ ] http://code.google.com/p/maven-android-plugin with 1 occurrences migrated to:  
  https://code.google.com/p/maven-android-plugin ([https](https://code.google.com/p/maven-android-plugin) result 301).
* [ ] http://developer.android.com/sdk/eclipse-adt.html with 1 occurrences migrated to:  
  https://developer.android.com/sdk/eclipse-adt.html ([https](https://developer.android.com/sdk/eclipse-adt.html) result 301).
* [ ] http://developer.android.com/sdk/index.html with 1 occurrences migrated to:  
  https://developer.android.com/sdk/index.html ([https](https://developer.android.com/sdk/index.html) result 301).
* [ ] http://developers.facebook.com/docs/authentication/ with 1 occurrences migrated to:  
  https://developers.facebook.com/docs/authentication/ ([https](https://developers.facebook.com/docs/authentication/) result 301).